### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ const connector = new SchemaConnector()
      * @response {DiscoveryResponse} Discovery response object
      */
   })
-  .stateRefreshHandler((accessToken, response) => {
+  .stateRefreshHandler((accessToken, response, data) => {
     /**
-     * State refresh request. Respond with the current states of all devices. Called after
-     * device discovery runs.
+     * State refresh request. Respond with the current states of the requested devices. Called after
+     * device discovery runs and every time the information is refreshed, the list of required devices is in data.devices
      * @accessToken External cloud access token
      * @response {StateRefreshResponse} StateRefresh response object
      */


### PR DESCRIPTION
The current documentation says that stateRefreshHandler responds with the state of all devices, but it is necessary to respond with the state of the requested devices, otherwise, there is an error callback.