### PR TITLE
Add error option

### DIFF
--- a/lib/state/StateResponse.js
+++ b/lib/state/StateResponse.js
@@ -47,7 +47,7 @@ class StateResponse extends STBase {
    * @param {string} externalDeviceId
    * @returns {StateDevice}
    */
-  addDevice(externalDeviceId, states) {
+  addDevice(externalDeviceId, states, error) {
     if (! this.deviceState) {
       this.deviceState = [];
     }
@@ -58,6 +58,9 @@ class StateResponse extends STBase {
       for (const state of states) {
         device.addState(state)
       }
+    }
+    if (error) { 
+        device.setError(error.detail, error.errorEnum)
     }
     return device;
   }


### PR DESCRIPTION
There is a function for adding device errors to the response but there is no way to use it from the StateResponse class.
I just added it